### PR TITLE
Remove one member abstracts lint rule

### DIFF
--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -141,7 +141,8 @@ linter:
     # - null_check_on_nullable_type_parameter
     - null_closures
     - omit_local_variable_types
-    - one_member_abstracts
+    # For some cases is interesting create an abstract class with just one member, instead of use typeof syntax
+    # - one_member_abstracts
     - only_throw_errors
     - overridden_fields
     - package_api_docs

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -141,7 +141,29 @@ linter:
     # - null_check_on_nullable_type_parameter
     - null_closures
     - omit_local_variable_types
-    # For some cases is interesting create an abstract class with just one member, instead of use typeof syntax
+    # Avoid defining a one-member abstract class when a simple function will do.
+    #
+    # This is because there are some contexts where you may want to wrap a dependency to keep function signatures more
+    # succint. So, for instance, say that you have a dependency for a particular function, and you require that
+    # one-member abstracts should be followed, you will be required to pass it through as an argument.
+    #
+    # I.e.:
+    #
+    # WHILE THIS IS PREFERRED:
+    # String something(MyDependency dependency) => 'Implementation ' + dependency.getSomethingElse();
+    #
+    # WE SHOULD ALLOW THIS:
+    # abstract class MyDependentClass {
+    #   String something();
+    # }
+    #
+    # class MyDependentClassImpl implements MyDependentClass  {
+    #   MyDependentClassImpl(this.dependency);
+    #   MyDependency dependency;
+    #
+    #   @override
+    #   String something() => 'Implementation ' + dependency.getSomethingElse();
+    # }
     # - one_member_abstracts
     - only_throw_errors
     - overridden_fields


### PR DESCRIPTION
This is a Pull Request related to issue #5 
The purpose is disable the lint rule that recommend don't create abstract classes with just one method, like this for example: 

```dart
abstract class DeckRepository {
  Future<List<Deck>> getAllDecks();
}
``` 

I think just removing this rule from `analysis_options.yaml` file will resolve this, correct ?