### PR TITLE
Removes conflicting `avoid_annotating_with_dynamic` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 1.2.2
+## Unreleased
 
-- Removed conflicting `avoid_annotating_with_dynamic` rule.
+- Disabled `avoid_annotating_with_dynamic`.
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.2
+
+- Removed conflicting `avoid_annotating_with_dynamic` rule.
+
 ## 1.1.0
 
 - Added `library_private_types_in_public_api`, `prefer_null_aware_method_calls`, `require_trailing_commas` and

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -36,7 +36,6 @@ linter:
     # - always_specify_types
     - always_use_package_imports
     - annotate_overrides
-    - avoid_annotating_with_dynamic
     - avoid_bool_literals_in_conditional_expressions
     - avoid_catches_without_on_clauses
     # Read more why we should use Exceptions to be caught instead of

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -36,6 +36,9 @@ linter:
     # - always_specify_types
     - always_use_package_imports
     - annotate_overrides
+    # This lint conflicts directly with both `implicit-dynamic` (set to `false) and `implicit-dynamic-parameter` meaning
+    # that in some cases, one would have to explicitly ignore one or another rule and we don't want this inconsistency.
+    # - avoid_annotating_with_dynamic
     - avoid_bool_literals_in_conditional_expressions
     - avoid_catches_without_on_clauses
     # Read more why we should use Exceptions to be caught instead of

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: strict
-version: 1.1.0
+version: 1.2.2
 description: A heavily opinionated analysis_options for Dart/Flutter projects with strict - but justified - lint rules
 repository: https://github.com/olmps/strict
 issue_tracker: https://github.com/olmps/strict/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: strict
-version: 1.2.2
+version: 1.1.0
 description: A heavily opinionated analysis_options for Dart/Flutter projects with strict - but justified - lint rules
 repository: https://github.com/olmps/strict
 issue_tracker: https://github.com/olmps/strict/issues


### PR DESCRIPTION
`avoid_annotating_with_dynamic` conflicts directly with the option `implicit-dynamic` when it's set to `false` (which is the current scenario). Undesired impact of the conflict:

```dart
final List<dynamic> dynamicElementsList = ...;
final transformedList = dynamicElementsList.map((dynamic element) { // -> This conflicts
    ...
}).toList();
```

When adding `dynamic` type to `element` as the map argument, linter complaints that the dynamic type is implicit (because the `avoid_annotating_with_dynamic` is active). But removing the `dynamic` annotation breaks the code because `implicit-dynamic` is set to `false`.

Both scenarios are possible: disable `avoid_annotating_with_dynamic` rule or set `implicit-dynamic` to `true`. I personally like to use dynamic type, that's why I suggest to remove the rule.