### PR TITLE
Removing eol_at_end_of_file rule

### DIFF
--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -121,7 +121,8 @@ linter:
     - empty_catches
     - empty_constructor_bodies
     - empty_statements
-    - eol_at_end_of_file
+    # I don't see any kind of benefit in this rule
+    # - eol_at_end_of_file
     - exhaustive_cases
     - file_names
     - flutter_style_todos

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -21,6 +21,7 @@ analyzer:
 # useful enough (meaning that we agree with its particular point of view).
 linter:
   rules:
+    - use_super_parameters
     - always_declare_return_types
     - always_put_control_body_on_new_line
     - always_put_required_named_parameters_first

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,4 +5,4 @@ repository: https://github.com/olmps/strict
 issue_tracker: https://github.com/olmps/strict/issues
 
 environment:
-  sdk: ">=2.16.1 <3.0.0"
+  sdk: ">=2.18.5 <3.0.0"


### PR DESCRIPTION
I don't see any kind of benefit in this rule